### PR TITLE
Fix bug that was showing up in tests/write.rs

### DIFF
--- a/src/cqe.rs
+++ b/src/cqe.rs
@@ -73,11 +73,7 @@ impl<'a> CompletionQueueEvent<'a> {
     }
 
     pub fn result(&self) -> io::Result<usize> {
-        if self.cqe.res >= 0 {
-            Ok(self.cqe.res as _)
-        } else {
-            Err(io::Error::from_raw_os_error(self.cqe.res as _))
-        }
+        resultify!(self.cqe.res)
     }
 
     pub fn raw(&self) -> &sys::io_uring_cqe {

--- a/tests/write.rs
+++ b/tests/write.rs
@@ -33,8 +33,8 @@ fn write_test() -> io::Result<()> {
             let bufs = [io::IoSlice::new(TEXT)];
             sqe.prep_write_vectored(file.as_raw_fd(), &bufs, 0);
             sqe.set_user_data(0xDEADBEEF);
+            io_uring.sq().submit()?;
         }
-        io_uring.sq().submit()?;
 
         let mut cq = io_uring.cq();
         let cqe = cq.wait_for_cqe()?;


### PR DESCRIPTION
A lifetime bug with the buffers passed to the SQE: the intermediate iovec did not live until the SQE was submitted.