### PR TITLE
Possible SIGSEGV fix for IoUring::peek_for_cqe

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,10 +183,13 @@ impl IoUring {
     pub fn peek_for_cqe(&mut self) -> Option<CompletionQueueEvent<'_>> {
         unsafe {
             let mut cqe = MaybeUninit::uninit();
-            sys::io_uring_peek_batch_cqe(&mut self.ring, cqe.as_mut_ptr(), 1);
-            let cqe = cqe.assume_init();
-            if cqe != ptr::null_mut() {
-                Some(CompletionQueueEvent::new(NonNull::from(&self.ring), &mut *cqe))
+            let count = sys::io_uring_peek_batch_cqe(&mut self.ring, cqe.as_mut_ptr(), 1);
+
+            if count > 0 {
+                Some(CompletionQueueEvent::new(NonNull::from(
+                    &self.ring),
+                    &mut *cqe.assume_init()
+                ))
             } else {
                 None
             }


### PR DESCRIPTION
Hi :wave:,

Thanks for writing this repo and also for all your awesome work on async/await!

I stumbled across segmentation fault and think this PR should fix it.  I'm much less familiar with Rust than C so apologies if the fix is incorrect.

Either way, I created a demonstration repo so it should be very easy to at least replicate the segfault.

You can find [the repo here](https://github.com/michael-grunder/iou-example-project).

Cheers!
Mike