### PR TITLE
Remove incorrect flag setting from fixed IO prep.

### DIFF
--- a/src/sqe.rs
+++ b/src/sqe.rs
@@ -131,7 +131,6 @@ impl<'a> SubmissionQueueEvent<'a> {
         self.sqe.addr = addr as _;
         self.sqe.len = len as _;
         self.sqe.buf_index.buf_index = buf_index as _;
-        self.sqe.flags |= SubmissionFlags::FIXED_FILE.bits();
     }
 
     #[inline]
@@ -166,7 +165,6 @@ impl<'a> SubmissionQueueEvent<'a> {
         self.sqe.addr = addr as _;
         self.sqe.len = len as _;
         self.sqe.buf_index.buf_index = buf_index as _;
-        self.sqe.flags |= SubmissionFlags::FIXED_FILE.bits();
     }
 
     #[inline]


### PR DESCRIPTION
The flag should be set for pre-registered fds, not pre-registered buffers.