### PR TITLE
Stop re-exporting uring-sys.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,4 @@ edition = "2018"
 
 [dependencies]
 bitflags = "1.2.0"
-
-[dependencies.uring-sys]
-version = "1.0.0-beta"
+uring-sys = "1.0.0-beta"

--- a/src/registrar.rs
+++ b/src/registrar.rs
@@ -3,10 +3,10 @@ use std::marker::PhantomData;
 use std::ptr::NonNull;
 use std::os::unix::io::RawFd;
 
-use super::{IoUring, sys};
+use super::IoUring;
 
 pub struct Registrar<'ring> {
-    ring: NonNull<sys::io_uring>,
+    ring: NonNull<uring_sys::io_uring>,
     _marker: PhantomData<&'ring mut IoUring>,
 }
 
@@ -21,14 +21,14 @@ impl<'ring> Registrar<'ring> {
         let len = buffers.len();
         let addr = buffers.as_ptr() as *const _;
         let _: i32 = resultify!(unsafe {
-            sys::io_uring_register_buffers(self.ring.as_ptr(), addr, len as _)
+            uring_sys::io_uring_register_buffers(self.ring.as_ptr(), addr, len as _)
         })?;
         Ok(())
     }
 
     pub fn unregister_buffers(&self) -> io::Result<()> {
         let _: i32 = resultify!(unsafe {
-            sys::io_uring_unregister_buffers(self.ring.as_ptr())
+            uring_sys::io_uring_unregister_buffers(self.ring.as_ptr())
         })?;
         Ok(())
     }
@@ -37,28 +37,28 @@ impl<'ring> Registrar<'ring> {
         let len = files.len();
         let addr = files.as_ptr();
         let _: i32 = resultify!(unsafe {
-            sys::io_uring_register_files(self.ring.as_ptr(), addr, len as _)
+            uring_sys::io_uring_register_files(self.ring.as_ptr(), addr, len as _)
         })?;
         Ok(())
     }
 
     pub fn unregister_files(&self) -> io::Result<()> {
         let _: i32 = resultify!(unsafe {
-            sys::io_uring_unregister_files(self.ring.as_ptr())
+            uring_sys::io_uring_unregister_files(self.ring.as_ptr())
         })?;
         Ok(())
     }
 
     pub fn register_eventfd(&self, eventfd: RawFd) -> io::Result<()> {
         let _: i32 = resultify!(unsafe {
-            sys::io_uring_register_eventfd(self.ring.as_ptr(), eventfd)
+            uring_sys::io_uring_register_eventfd(self.ring.as_ptr(), eventfd)
         })?;
         Ok(())
     }
 
     pub fn unregister_eventfd(&self) -> io::Result<()> {
         let _: i32 = resultify!(unsafe {
-            sys::io_uring_unregister_eventfd(self.ring.as_ptr())
+            uring_sys::io_uring_unregister_eventfd(self.ring.as_ptr())
         })?;
         Ok(())
     }


### PR DESCRIPTION
This is a legacy of a time in the development history when uring-sys was
*actually* just a submodule of iou. But its its own crate with its own
identity, API, versioning plan, etc, and we shouldn't re-expor the
entire thing.