### PR TITLE
Cqe iterator

### DIFF
--- a/src/cqe.rs
+++ b/src/cqe.rs
@@ -284,7 +284,7 @@ impl<'a> CompletionQueueEvent<'a> {
         if  !cqe.is_timeout() {
             Ok(Some(cqe))
         } else {
-            Ok(None)
+            cqe.result().map(|_| None)
         }
     }
 

--- a/src/cqe.rs
+++ b/src/cqe.rs
@@ -24,40 +24,161 @@ impl<'ring> CompletionQueue<'ring> {
     }
 
     pub fn peek_for_cqe(&mut self) -> Option<CompletionQueueEvent<'_>> {
-        unsafe {
-            let mut cqe = MaybeUninit::uninit();
-            let count = uring_sys::io_uring_peek_batch_cqe(self.ring.as_ptr(), cqe.as_mut_ptr(), 1);
-            if count > 0 {
-                Some(CompletionQueueEvent::new(self.ring.as_ptr(), &mut *cqe.assume_init()))
-            } else {
-                None
-            }
-        }
+        unsafe { peek_for_one(self.ring) }
     }
 
     pub fn wait_for_cqe(&mut self) -> io::Result<CompletionQueueEvent<'_>> {
-        self.wait_for_cqes(1)
+        unsafe { wait_for_one(self.ring, ptr::null()) }
     }
 
-    pub fn wait_for_cqes(&mut self, count: usize) -> io::Result<CompletionQueueEvent<'_>> {
-        unsafe {
-            let mut cqe = MaybeUninit::uninit();
+    pub fn peek_for_cqes(&mut self) -> CompletionQueueEvents<'_> {
+        unsafe { CompletionQueueEvents::peek(self.ring) }
+    }
 
-            let _: i32 = resultify!(uring_sys::io_uring_wait_cqes(
-                self.ring.as_ptr(),
-                cqe.as_mut_ptr(),
-                count as _,
-                ptr::null(),
-                ptr::null(),
-            ))?;
-
-            Ok(CompletionQueueEvent::new(self.ring.as_ptr(), &mut *cqe.assume_init()))
-        }
+    pub fn wait_for_cqes(&mut self, count: usize) -> io::Result<CompletionQueueEvents<'_>> {
+        unsafe { CompletionQueueEvents::wait(self.ring, count, ptr::null()) }
     }
 }
 
 unsafe impl<'ring> Send for CompletionQueue<'ring> { }
 unsafe impl<'ring> Sync for CompletionQueue<'ring> { }
+
+pub struct CompletionQueueEvents<'a> {
+    ring: NonNull<uring_sys::io_uring>,
+    ptr: *mut uring_sys::io_uring_cqe,
+    available: usize,
+    seen: usize,
+    filter_timeouts: bool,
+    _marker: PhantomData<&'a mut IoUring>,
+}
+
+impl<'a> CompletionQueueEvents<'a> {
+    // unsafe contract:
+    //  - ring must not be dangling
+    //  - this returns a CQE iterator with an arbitrary lifetime, you must have logically exclusive
+    //    access to the CQ for that lifetime
+    //  - if ts is nonnull, you must have logically exclusive access to the SQ as well as CQ and ts
+    //    must point to a valid __kernel_timespec
+    pub(crate) unsafe fn wait(
+        ring: NonNull<uring_sys::io_uring>,
+        count: usize,
+        ts: *const uring_sys::__kernel_timespec
+    ) -> io::Result<CompletionQueueEvents<'a>> {
+        let mut cqe = MaybeUninit::uninit();
+        let available = wait(ring, &mut cqe, count, ts)?;
+        if available != 0 {
+            Ok(CompletionQueueEvents {
+                ring: ring,
+                available,
+                ptr: cqe.assume_init(),
+                seen: 0,
+                filter_timeouts: false,
+                _marker: PhantomData,
+            })
+        } else {
+            Ok(CompletionQueueEvents::peek(ring))
+        }
+    }
+
+    // unsafe contract:
+    //  - ring must not be dangling
+    //  - this returns a CQE iterator with an arbitrary lifetime, you must have logically exclusive
+    //    access to the CQ for that lifetime
+    pub(crate) unsafe fn peek(ring: NonNull<uring_sys::io_uring>) -> CompletionQueueEvents<'a> {
+        CompletionQueueEvents {
+            ring,
+            ptr: ptr::null_mut(),
+            available: 0,
+            seen: 0,
+            filter_timeouts: false,
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn next_cqe(&mut self) -> Option<CompletionQueueEvent<'_>> {
+        'skip_timeouts: loop {
+            unsafe {
+                // If none are available, peek to see if there are more, resetting
+                // the number of available CQEs to the total number of ready CQEs
+                // minus the number of seen CQEs.
+                if self.available == 0 {
+                    let mut cqe = MaybeUninit::uninit();
+                    let ready = peek(self.ring, &mut cqe);
+
+                    self.available = ready - self.seen;
+
+                    // If there are still none available, return None
+                    if self.available == 0 {
+                        return None;
+                    }
+
+                    // Otherwise, if self.ptr is null (meaning we have never
+                    // returned a CQE yet), set it to be the first available
+                    // CQE.
+                    if self.ptr == ptr::null_mut() {
+                        self.ptr = cqe.assume_init();
+                    }
+                }
+
+                // Construct a CQE from self.ptr, now that we know there is at least one more
+                // CQE available and our pointer is non-null. We pass a null pointer for the
+                // ring so that it will not advance the queue on drop.
+                let cqe = CompletionQueueEvent::new(ptr::null_mut(), &mut *self.ptr);
+
+                // Advance the pointer and our counters because we have now taken this pointer
+                self.ptr = self.ptr.offset(1);
+                self.available -= 1;
+                self.seen += 1;
+
+                // If we are filtering timeouts and this CQE is a timeout, repeat this process.
+                // Otherwise, return this CQE.
+                if self.filter_timeouts && cqe.is_timeout() {
+                    continue 'skip_timeouts;
+                }
+                
+                return Some(cqe);
+            }
+        }
+    }
+
+    pub fn for_each(&mut self, mut f: impl FnMut(CompletionQueueEvent<'_>)) {
+        while let Some(cqe) = self.next_cqe() {
+            f(cqe);
+        }
+    }
+
+    pub fn try_for_each<E>(&mut self, mut f: impl FnMut(CompletionQueueEvent<'_>) -> Result<(), E>)
+        -> Result<(), E>
+    {
+        while let Some(cqe) = self.next_cqe() {
+            f(cqe)?;
+        }
+        Ok(())
+    }
+
+    pub fn filter_timeouts(&mut self, flag: bool) {
+        self.filter_timeouts = flag;
+    }
+
+    pub fn advance_queue(&mut self) {
+        unsafe {
+            uring_sys::io_uring_cq_advance(self.ring.as_ptr(), self.seen as _);
+        }
+        self.seen = 0;
+    }
+}
+
+impl<'a> Drop for CompletionQueueEvents<'a> {
+    fn drop(&mut self) {
+        // Advance the CQ by as many CQEs as we have seen using this iterator.
+        unsafe {
+            uring_sys::io_uring_cq_advance(self.ring.as_ptr(), self.seen as _);
+        }
+    }
+}
+
+unsafe impl<'a> Send for CompletionQueueEvents<'a> { }
+unsafe impl<'a> Sync for CompletionQueueEvents<'a> { }
 
 /// A completed IO event.
 pub struct CompletionQueueEvent<'a> {
@@ -66,7 +187,9 @@ pub struct CompletionQueueEvent<'a> {
 }
 
 impl<'a> CompletionQueueEvent<'a> {
-    pub(crate) fn new(ring: *mut uring_sys::io_uring, cqe: &'a mut uring_sys::io_uring_cqe) -> CompletionQueueEvent<'a> {
+    pub(crate) fn new(ring: *mut uring_sys::io_uring, cqe: &'a mut uring_sys::io_uring_cqe)
+        -> CompletionQueueEvent<'a>
+    {
         CompletionQueueEvent { ring, cqe }
     }
 
@@ -111,8 +234,8 @@ impl<'a> CompletionQueueEvent<'a> {
 
 impl<'a> Drop for CompletionQueueEvent<'a> {
     fn drop(&mut self) {
-        unsafe {
-            if self.ring != ptr::null_mut() {
+        if self.ring != ptr::null_mut() {
+            unsafe {
                 uring_sys::io_uring_cqe_seen(self.ring, self.cqe);
             }
         }
@@ -121,3 +244,77 @@ impl<'a> Drop for CompletionQueueEvent<'a> {
 
 unsafe impl<'a> Send for CompletionQueueEvent<'a> { }
 unsafe impl<'a> Sync for CompletionQueueEvent<'a> { }
+
+// unsafe contract:
+//  - ring must not be dangling
+//  - you must have logically exclusive access to the CQ for this function call
+//
+// NOTE: The pointer offsetting is hand-written because there is no API currently in liburing that
+// returns the next CQE and also an accurate count of how many CQEs are ready in only one
+// synchronization.
+pub(crate) unsafe fn peek<'a>(
+    ring: NonNull<uring_sys::io_uring>,
+    cqe: &mut MaybeUninit<*mut uring_sys::io_uring_cqe>
+) -> usize
+{
+    let ring = ring.as_ptr();
+    let count = uring_sys::io_uring_cq_ready(ring);
+
+    if count != 0 {
+        let head = *(*ring).cq.khead as usize;
+        let mask = *(*ring).cq.kring_mask as usize;
+        *cqe.as_mut_ptr() = (*ring).cq.cqes.offset((head & mask) as isize);
+    }
+
+    count as usize
+}
+
+// unsafe contract:
+//  - ring must not be dangling
+//  - this returns a CQE with an arbitrary lifetime, you must have logically exclusive access to
+//    the CQ for that lifetime
+#[inline(always)]
+pub(crate) unsafe fn peek_for_one<'a>(ring: NonNull<uring_sys::io_uring>)
+    -> Option<CompletionQueueEvent<'a>>
+{
+    let mut cqe = MaybeUninit::uninit();
+    if peek(ring, &mut cqe) > 0 {
+        Some(CompletionQueueEvent::new(ring.as_ptr(), &mut *cqe.assume_init()))
+    } else {
+        None
+    }
+}
+
+
+// unsafe contract:
+//  - ring must not be dangling
+//  - you must have logically exclusive access to the CQ for this function call
+//  - if ts is nonnull, you must have logically exclusive access to the SQ as well as CQ and ts
+//    must point to a valid __kernel_timespec
+#[inline(always)]
+pub(crate) unsafe fn wait(
+    ring: NonNull<uring_sys::io_uring>,
+    cqe: &mut MaybeUninit<*mut uring_sys::io_uring_cqe>,
+    count: usize,
+    ts: *const uring_sys::__kernel_timespec
+) -> io::Result<usize> {
+    let ring = ring.as_ptr();
+    let cqe = cqe.as_mut_ptr();
+    resultify!(uring_sys::io_uring_wait_cqes(ring, cqe, count as _, ts, ptr::null()))
+}
+
+// unsafe contract:
+//  - ring must not be dangling
+//  - this returns a CQE with an arbitrary lifetime, you must have logically exclusive access to
+//    the CQ for that lifetime
+//  - if ts is nonnull, you must have logically exclusive access to the SQ as well as CQ and ts
+//    must point to a valid __kernel_timespec
+#[inline(always)]
+pub(crate) unsafe fn wait_for_one<'a>(
+    ring: NonNull<uring_sys::io_uring>,
+    ts: *const uring_sys::__kernel_timespec
+) -> io::Result<CompletionQueueEvent<'a>> {
+    let mut cqe = MaybeUninit::uninit();
+    wait(ring, &mut cqe, 1, ts)?;
+    Ok(CompletionQueueEvent::new(ring.as_ptr(), &mut *cqe.assume_init()))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,6 +285,14 @@ impl Drop for IoUring {
 unsafe impl Send for IoUring { }
 unsafe impl Sync for IoUring { }
 
+#[inline(always)]
+fn timespec(duration: Duration) -> uring_sys::__kernel_timespec {
+    uring_sys::__kernel_timespec {
+        tv_sec: duration.as_secs() as _,
+        tv_nsec: duration.subsec_nanos() as _
+    }
+}
+
 // This has to live in an inline module to test the non-exported resultify macro.
 #[cfg(test)]
 mod tests {
@@ -309,13 +317,5 @@ mod tests {
         let ret: Result<i32, _> = resultify!(side_effect(-1, &mut calls));
         assert!(match ret { Err(e) if e.raw_os_error() == Some(1) => true, _ => false });
         assert_eq!(calls, 1);
-    }
-}
-
-#[inline(always)]
-fn timespec(duration: Duration) -> uring_sys::__kernel_timespec {
-    uring_sys::__kernel_timespec {
-        tv_sec: duration.as_secs() as _,
-        tv_nsec: duration.subsec_nanos() as _
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ mod registrar;
 
 use std::io;
 use std::mem::MaybeUninit;
-use std::ptr::{self, NonNull};
+use std::ptr;
 use std::time::Duration;
 
 pub use sqe::{SubmissionQueue, SubmissionQueueEvent, SubmissionFlags, FsyncFlags};
@@ -211,10 +211,7 @@ impl IoUring {
             let count = uring_sys::io_uring_peek_batch_cqe(&mut self.ring, cqe.as_mut_ptr(), 1);
 
             if count > 0 {
-                Some(CompletionQueueEvent::new(NonNull::from(
-                    &self.ring),
-                    &mut *cqe.assume_init()
-                ))
+                Some(CompletionQueueEvent::new(&mut self.ring, &mut *cqe.assume_init()))
             } else {
                 None
             }
@@ -265,7 +262,7 @@ impl IoUring {
                 ptr::null(),
             ))?;
 
-            Ok(CompletionQueueEvent::new(NonNull::from(&self.ring), &mut *cqe.assume_init()))
+            Ok(CompletionQueueEvent::new(&mut self.ring, &mut *cqe.assume_init()))
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,7 +210,7 @@ impl IoUring {
     /// If there is at least one CompletionQueueEvent ready on the queue, this
     /// will return it. If there aren't any ready, it will return `None`.
     pub fn peek_for_cqe(&mut self) -> Option<CompletionQueueEvent<'_>> {
-        unsafe { cqe::peek_for_one(NonNull::from(&mut self.ring)) }
+        unsafe { CompletionQueueEvent::peek(NonNull::from(&mut self.ring)) }
     }
 
     /// Wait for at least one CompletionQueueEvent to be ready, blocking this thread.
@@ -219,7 +219,7 @@ impl IoUring {
     /// on the completion queue, then returns the first of those. There may be more
     /// events ready after, which you can check with the `peek` methods.
     pub fn wait_for_cqe(&mut self) -> io::Result<CompletionQueueEvent<'_>> {
-        unsafe { cqe::wait_for_one(NonNull::from(&mut self.ring), ptr::null()) }
+        unsafe { CompletionQueueEvent::wait(NonNull::from(&mut self.ring), ptr::null()) }
     }
 
     /// Wait for at least one CompletionQueueEvent to be ready, blocking with a
@@ -233,7 +233,7 @@ impl IoUring {
     pub fn wait_for_cqe_with_timeout(&mut self, duration: Duration)
         -> io::Result<CompletionQueueEvent<'_>>
     {
-        unsafe { cqe::wait_for_one(NonNull::from(&mut self.ring), &timespec(duration)) }
+        unsafe { CompletionQueueEvent::wait(NonNull::from(&mut self.ring), &timespec(duration)) }
     }
 
     /// Check if any CompletionQueueEvents are ready, without blocking.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,7 +247,7 @@ impl IoUring {
     /// This returns CompletionQueueEvents type, which acts like an iterator of
     /// events (though it doesn't implement Iterator unfortunately). It will
     /// keep yielding events until there are none left to yield.
-    pub fn peek_for_cqes(&mut self) -> CompletionQueueEvents<'_> {
+    pub fn peek_for_cqes<F>(&mut self) -> CompletionQueueEvents<'_, F> {
         unsafe { CompletionQueueEvents::peek(NonNull::from(&mut self.ring)) }
     }
 
@@ -260,13 +260,13 @@ impl IoUring {
     ///
     /// That means that this will yield at least `count` CompletionQueueEvents,
     /// but it may also yield more than that.
-    pub fn wait_for_cqes(&mut self, count: usize) -> io::Result<CompletionQueueEvents<'_>> {
+    pub fn wait_for_cqes<F>(&mut self, count: usize) -> io::Result<CompletionQueueEvents<'_, F>> {
         let ring = NonNull::from(&mut self.ring);
         unsafe { CompletionQueueEvents::wait(ring, count, ptr::null()) }
     }
 
-    pub fn wait_for_cqes_with_timeout(&mut self, count: usize, duration: Duration)
-        -> io::Result<CompletionQueueEvents<'_>>
+    pub fn wait_for_cqes_with_timeout<F>(&mut self, count: usize, duration: Duration)
+        -> io::Result<CompletionQueueEvents<'_, F>>
     {
         let ring = NonNull::from(&mut self.ring);
         let ts = timespec(duration);

--- a/src/sqe.rs
+++ b/src/sqe.rs
@@ -102,10 +102,7 @@ impl<'ring> SubmissionQueue<'ring> {
     pub fn submit_and_wait_with_timeout(&mut self, wait_for: u32, duration: Duration)
         -> io::Result<usize>
     {
-        let ts = uring_sys::__kernel_timespec {
-            tv_sec: duration.as_secs() as _,
-            tv_nsec: duration.subsec_nanos() as _
-        };
+        let ts = crate::timespec(duration);
 
         loop {
             if let Some(mut sqe) = self.next_sqe() {

--- a/src/sqe.rs
+++ b/src/sqe.rs
@@ -116,10 +116,6 @@ impl<'ring> SubmissionQueue<'ring> {
             self.submit()?;
         }
     }
-
-    pub(crate) fn ring(&self) -> NonNull<uring_sys::io_uring> {
-        self.ring
-    }
 }
 
 unsafe impl<'ring> Send for SubmissionQueue<'ring> { }

--- a/src/sqe.rs
+++ b/src/sqe.rs
@@ -116,6 +116,10 @@ impl<'ring> SubmissionQueue<'ring> {
             self.submit()?;
         }
     }
+
+    pub(crate) fn ring(&self) -> NonNull<uring_sys::io_uring> {
+        self.ring
+    }
 }
 
 unsafe impl<'ring> Send for SubmissionQueue<'ring> { }

--- a/tests/cqe_iterator.rs
+++ b/tests/cqe_iterator.rs
@@ -1,0 +1,40 @@
+use std::io;
+
+#[test]
+fn iterator_test() -> io::Result<()> {
+    unsafe {
+        let mut io_uring = iou::IoUring::new(32)?;
+
+        let mut sqe = io_uring.next_sqe().unwrap();
+        sqe.prep_nop();
+        sqe.set_user_data(0x01);
+
+        let mut sqe = io_uring.next_sqe().unwrap();
+        sqe.prep_nop();
+        sqe.set_user_data(0x02);
+
+        let mut sqe = io_uring.next_sqe().unwrap();
+        sqe.prep_nop();
+        sqe.set_user_data(0x03);
+
+        io_uring.submit_sqes()?;
+
+        let mut user_datas = [0x01, 0x02, 0x03];
+        io_uring.wait_for_cqes(3).unwrap().for_each(|cqe| {
+
+            let ud = user_datas.iter_mut().find(|&&mut ud| cqe.user_data() == ud)
+                                          .expect("received unexpected CQE");
+
+            if *ud == 0 { panic!("received same CQE more than once") } else { *ud = 0; }
+
+        });
+
+        assert_eq!(user_datas, [0x00, 0x00, 0x00]);
+
+        let mut count = 0;
+        io_uring.peek_for_cqes().for_each(|_| count += 1);
+        assert_eq!(count, 0, "all CQEs should be processed");
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
This adds a new API for processing CQEs as a psuedo-Iterator. Now, the APIs which return multiple CQEs (ending with `for_cqes`) return a `CompletionQueueEvents` type, which has a `next_cqe` and `for_each` method, which allow the user to advance through the ready CQEs on the queue.

This API is designed to synchronize with the kernel as few times as possible while processing all available CQEs. This is good if the code you perform for each CQE is very fast, but it can lead to a backed-up CQ if that code takes significant time. For example, this API would be good for a use which wakes tasks when IO events complete (e.g. in the reactor of a Rust Futures API), but not so much for something which actually completes the tasks synchronously on the same thread the events are completed.

This commit also collapses some repetitious unsafe code into singular underlying peek and wait functions, so that we should hopefully not see divergences and bugs.

Closes #14. There's substantial changes to unsafe code here, so I'd like other reviews and will review myself again next week before merging.