### PR TITLE
Add explicit registered file type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ use std::time::Duration;
 
 pub use sqe::{SubmissionQueue, SubmissionQueueEvent, SubmissionFlags, FsyncFlags, SockAddrStorage};
 pub use cqe::{CompletionQueue, CompletionQueueEvent};
-pub use registrar::Registrar;
+pub use registrar::{Registrar, RingFd, RegisteredFd};
 
 pub use nix::poll::PollFlags;
 pub use nix::sys::socket::{

--- a/src/registrar.rs
+++ b/src/registrar.rs
@@ -1,3 +1,4 @@
+use std::convert::TryInto;
 use std::io;
 use std::marker::PhantomData;
 use std::ptr::NonNull;
@@ -10,8 +11,19 @@ use super::IoUring;
 /// Pre-registering kernel IO references greatly reduces per-IO overhead.
 /// The kernel no longer needs to obtain and drop file references or map kernel memory for each operation.
 /// Consider registering frequently used files and buffers.
+/// ```
+/// # use iou::{IoUring, Registrar};
+/// # fn main() -> std::io::Result<()> {
+/// let mut ring = IoUring::new(8)?;
+/// let mut registrar: Registrar = ring.registrar();
+/// # let fds = &[0, 1];
+/// registrar.register_files(fds)?;
+/// # Ok(())
+/// # }
+/// ```
 pub struct Registrar<'ring> {
     ring: NonNull<uring_sys::io_uring>,
+    fileset: Vec<RegisteredFd>,
     _marker: PhantomData<&'ring mut IoUring>,
 }
 
@@ -19,8 +31,14 @@ impl<'ring> Registrar<'ring> {
     pub(crate) fn new(ring: &'ring IoUring) -> Registrar<'ring> {
         Registrar {
             ring: NonNull::from(&ring.ring),
+            fileset: Vec::new(),
             _marker: PhantomData,
         }
+    }
+
+    /// Get the set of currently registered files.
+    pub fn fileset(&self) -> &[RegisteredFd] {
+        &self.fileset
     }
 
     /// Register a set of buffers to be mapped into the kernel.
@@ -42,21 +60,93 @@ impl<'ring> Registrar<'ring> {
         Ok(())
     }
 
-    pub fn register_files(&self, files: &[RawFd]) -> io::Result<()> {
+    /// Register a set of files with the kernel. Registered files handle kernel fileset indexing behind the scenes and can often be used in place of raw file descriptors.
+    /// ```
+    /// # use iou::IoUring;
+    /// # fn main() -> std::io::Result<()> {
+    /// # let mut ring = IoUring::new(2)?;
+    /// # let mut registrar = ring.registrar();
+    /// # let raw_fds = [1, 2];
+    /// # let bufs = &[std::io::IoSlice::new(b"hi")];
+    /// registrar.register_files(&raw_fds)?;
+    /// let reg_file = registrar.fileset()[0];
+    /// # let mut sqe = ring.next_sqe().unwrap();
+    /// unsafe { sqe.prep_write_vectored(reg_file, bufs, 0); }
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn register_files(&mut self, files: &[RawFd]) -> io::Result<()> {
         let len = files.len();
-        let addr = files.as_ptr();
+        let addr = files.as_ptr() as *const _;
+
         let _: i32 = resultify!(unsafe {
             uring_sys::io_uring_register_files(self.ring.as_ptr(), addr, len as _)
         })?;
+
+        self.fileset = files
+            .iter()
+            .enumerate()
+            .map(|(i, &fd)| RegisteredFd::new(i, fd))
+            .collect();
+
+        Ok(())
+    }
+
+    /// Update the currently registered kernel fileset. It is usually more efficient to reserve space for files before submitting events, because `IoUring` will wait until the submission queue is
+    /// empty before registering files.
+    /// # Panics
+    /// Panics if `offset` is out of bounds or if the `files` buffer is too large.
+    pub fn update_registered_files(&mut self, offset: usize, files: &[RawFd]) -> io::Result<()> {
+        if offset + files.len() > self.fileset.len() {
+            panic!("attempted out of bounds update for kernel fileset");
+        }
+
+        let len = files.len();
+        let addr = files.as_ptr() as *const _;
+
+        let _: i32 = resultify!(unsafe {
+            uring_sys::io_uring_register_files_update(
+                self.ring.as_ptr(),
+                offset as _,
+                addr,
+                len as _,
+            )
+        })?;
+
+        self.fileset.splice(
+            offset..(offset + files.len()),
+            (offset..)
+                .zip(files.iter())
+                .map(|(i, &fd)| RegisteredFd::new(i, fd))
+                .collect::<Vec<_>>(),
+        );
+
         Ok(())
     }
 
     /// Unregister all currently registered files. An explicit call to this method is often unecessary,
     /// because all files will be unregistered automatically when the ring is dropped.
-    pub fn unregister_files(&self) -> io::Result<()> {
-        let _: i32 = resultify!(unsafe {
-            uring_sys::io_uring_unregister_files(self.ring.as_ptr())
-        })?;
+    ///
+    /// You can use this method to replace an existing fileset:
+    /// ```
+    /// # use iou::IoUring;
+    /// # fn main() -> std::io::Result<()> {
+    /// # let mut ring = IoUring::new(2)?;
+    /// # let mut registrar = ring.registrar();
+    /// # let raw_fds = [1, 2];
+    /// # let bufs = &[std::io::IoSlice::new(b"hi")];
+    /// registrar.register_files(&raw_fds)?;
+    /// assert!(!registrar.fileset().is_empty());
+    ///
+    /// registrar.unregister_files()?;
+    /// assert!(registrar.fileset().is_empty());
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn unregister_files(&mut self) -> io::Result<()> {
+        let _: i32 =
+            resultify!(unsafe { uring_sys::io_uring_unregister_files(self.ring.as_ptr()) })?;
+        self.fileset.clear();
         Ok(())
     }
 
@@ -77,3 +167,118 @@ impl<'ring> Registrar<'ring> {
 
 unsafe impl<'ring> Send for Registrar<'ring> { }
 unsafe impl<'ring> Sync for Registrar<'ring> { }
+
+/// A member of the kernel's registered fileset.
+///
+/// Valid `RegisteredFd`s can only be obtained through a [`Registrar`](crate::registrar::Registrar).
+///
+/// Registered files handle kernel fileset indexing behind the scenes and can often be used in place of raw file descriptors. Not all IO operations support registered files.
+///
+/// Submission event prep methods on `RegisteredFd` will ensure that the submission event's `SubmissionFlags::FIXED_FILE` flag is properly set.
+///
+/// # Panics
+/// In order to reserve kernel fileset space, `RegisteredFd`s can be placeholders.
+/// Placeholders can be interspersed with actual files. Submitted IO events on placeholders will panic.
+#[derive(Debug, Copy, Clone)]
+#[repr(transparent)]
+pub struct RegisteredFd {
+    index: RawFd,
+}
+
+impl RegisteredFd {
+    pub(crate) fn new(index: usize, fd: RawFd) -> RegisteredFd {
+        if fd == -1 {
+            RegisteredFd::placeholder()
+        } else {
+            RegisteredFd {
+                index: index.try_into().unwrap(),
+            }
+        }
+    }
+
+    /// Get a new `RegisteredFd` placeholder. Used to reserve kernel fileset entries.
+    pub fn placeholder() -> RegisteredFd {
+        RegisteredFd { index: -1 }
+    }
+
+    /// Returns this file's kernel fileset index as a raw file descriptor.
+    pub fn as_fd(self) -> RawFd {
+        self.index
+    }
+
+    /// Check whether this is a placeholder value.
+    pub fn is_placeholder(self) -> bool {
+        self.index == -1
+    }
+}
+
+/// IoUring file handles.
+#[derive(Debug, Copy, Clone)]
+pub enum RingFd {
+    /// A raw file descriptor.
+    Raw(RawFd),
+    /// A member of the kernel's fixed fileset.
+    Registered(RegisteredFd),
+}
+
+impl RingFd {
+    pub fn raw(self) -> RawFd {
+        match self {
+            RingFd::Raw(fd) => fd,
+            RingFd::Registered(index) => index.as_fd(),
+        }
+    }
+}
+
+impl From<RawFd> for RingFd {
+    fn from(item: RawFd) -> RingFd {
+        RingFd::Raw(item)
+    }
+}
+
+impl From<RegisteredFd> for RingFd {
+    fn from(item: RegisteredFd) -> RingFd {
+        if item.is_placeholder() {
+            panic!("attempted to perform IO on kernel fileset placeholder");
+        }
+        RingFd::Registered(item)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    #[should_panic(expected = "attempted to perform IO on kernel fileset placeholder")]
+    fn placeholder_submit() {
+        let mut ring = IoUring::new(1).unwrap();
+        let mut sqe = ring.next_sqe().unwrap();
+
+        unsafe {
+            sqe.prep_read_vectored(RegisteredFd::placeholder(), &mut [], 0);
+        }
+    }
+
+    #[test]
+    #[should_panic]
+    // fails with device busy
+    fn double_register() {
+        let ring = IoUring::new(8).unwrap();
+        ring.registrar().register_files(&[1]).unwrap();
+        ring.registrar().register_files(&[1]).unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "attempted out of bounds update for kernel fileset")]
+    fn out_of_bounds_update() {
+        let raw_fds = [1, 2];
+        let ring = IoUring::new(8).unwrap();
+        ring.registrar().register_files(&raw_fds).unwrap();
+        ring.registrar().unregister_files().unwrap();
+        ring.registrar()
+            .update_registered_files(0, &raw_fds)
+            .unwrap();
+    }
+}

--- a/src/sqe.rs
+++ b/src/sqe.rs
@@ -413,8 +413,6 @@ impl SockAddrStorage {
 
 bitflags::bitflags! {
     /// [`SubmissionQueueEvent`](SubmissionQueueEvent) configuration flags.
-    ///
-    /// Use a [`Registrar`](crate::registrar::Registrar) to register files for the `FIXED_FILE` flag.
     pub struct SubmissionFlags: u8 {
         /// This event's file descriptor is an index into the preregistered set of files.
         const FIXED_FILE    = 1 << 0;   /* use fixed fileset */

--- a/tests/fileset-placeholder.rs
+++ b/tests/fileset-placeholder.rs
@@ -1,0 +1,62 @@
+use iou::{IoUring, RegisteredFd, SubmissionFlags};
+use std::fs::{self, File};
+use std::io::{IoSlice, Read};
+use std::os::unix::io::AsRawFd;
+use std::path::PathBuf;
+use std::time::Duration;
+
+const TEXT: &[u8] = b"hello there\n";
+
+#[test]
+#[ignore] // fails if sparse filesets aren't supported
+fn main() -> std::io::Result<()> {
+    let mut ring = IoUring::new(2)?;
+    let mut registrar = ring.registrar();
+
+    let reserve_files = [RegisteredFd::placeholder().as_fd(), 4096];
+    registrar.register_files(&reserve_files)?;
+    assert!(registrar.fileset().iter().all(|fd| fd.is_placeholder()));
+
+    println!("makes it here");
+
+    let mut path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("props");
+    path.push("tmp-fileset-placeholder.txt");
+
+    let file = std::fs::File::create(&path)?;
+    let fd_slice = &[file.as_raw_fd()];
+
+    // update a random fileset entry
+    let offset = 713;
+
+    let reg_file = registrar.fileset()[offset];
+
+    registrar.update_registered_files(offset, fd_slice)?;
+    assert!(!registrar.fileset()[offset].is_placeholder());
+
+    let reg_file = registrar.fileset()[offset];
+
+    let bufs = &[IoSlice::new(&TEXT)];
+
+    let mut sqe = ring.next_sqe().unwrap();
+
+    unsafe {
+        sqe.prep_write_vectored(reg_file, bufs, 0);
+        sqe.set_user_data(0xDEADBEEF);
+    }
+
+    ring.submit_sqes()?;
+
+    let cqe = ring.wait_for_cqe()?;
+    assert_eq!(cqe.user_data(), 0xDEADBEEF);
+
+    let n = cqe.result()?;
+    assert!(n == TEXT.len());
+
+    let mut file = File::open(&path)?;
+    let mut buf = vec![];
+    file.read_to_end(&mut buf)?;
+    assert_eq!(&TEXT[..n], &buf[..n]);
+
+    Ok(())
+}

--- a/tests/fixed-file-write.rs
+++ b/tests/fixed-file-write.rs
@@ -24,7 +24,6 @@ fn read_fixed() -> std::io::Result<()> {
 
     let bufs = &[IoSlice::new(&TEXT)];
     let reg_file = fileset[0];
-    println!("{:?}", reg_file);
 
     let mut sqe = ring.next_sqe().unwrap();
 

--- a/tests/fixed-file-write.rs
+++ b/tests/fixed-file-write.rs
@@ -1,0 +1,53 @@
+use iou::{IoUring, RegisteredFd, Registrar};
+use std::fs::{self, File};
+use std::io::{IoSlice, Read};
+use std::os::unix::io::AsRawFd;
+use std::path::PathBuf;
+
+const TEXT: &[u8] = b"hello there";
+
+#[test]
+fn read_fixed() -> std::io::Result<()> {
+    let mut ring = IoUring::new(2)?;
+
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("props");
+    path.push("tmp.txt");
+
+    let file = File::create(&path)?;
+
+    let fixed_fd = file.as_raw_fd();
+    let mut reg: Registrar = ring.registrar();
+
+    // register a new set of files
+    let files = &[fixed_fd];
+    reg.register_files(files)?;
+
+    let bufs = &[IoSlice::new(&TEXT)];
+    let reg_file = reg.fileset()[0];
+    println!("{:?}", reg_file);
+
+    let mut sqe = ring.next_sqe().unwrap();
+
+    unsafe {
+        sqe.prep_write_vectored(reg_file, bufs, 0);
+        sqe.set_user_data(0xDEADBEEF);
+    }
+
+    ring.submit_sqes()?;
+
+    let cqe = ring.wait_for_cqe()?;
+    assert_eq!(cqe.user_data(), 0xDEADBEEF);
+
+    let n = cqe.result()?;
+    assert!(n == TEXT.len());
+
+    let mut file = File::open(&path)?;
+    let mut buf = vec![];
+    file.read_to_end(&mut buf)?;
+    assert_eq!(&TEXT[..n], &buf[..n]);
+
+    let _ = fs::remove_file(&path);
+
+    Ok(())
+}

--- a/tests/fixed-file-write.rs
+++ b/tests/fixed-file-write.rs
@@ -19,12 +19,11 @@ fn read_fixed() -> std::io::Result<()> {
     let fixed_fd = file.as_raw_fd();
     let mut reg: Registrar = ring.registrar();
 
-    // register a new set of files
-    let files = &[fixed_fd];
-    reg.register_files(files)?;
+    // register a new file
+    let fileset: Vec<RegisteredFd> = reg.register_files(&[fixed_fd])?.collect();
 
     let bufs = &[IoSlice::new(&TEXT)];
-    let reg_file = reg.fileset()[0];
+    let reg_file = fileset[0];
     println!("{:?}", reg_file);
 
     let mut sqe = ring.next_sqe().unwrap();


### PR DESCRIPTION
This PR reduces end user complexity for properly setting up fixed file IO in the kernel. 

The fixed file interface was a little confusing for me (as opposed to fixed buffers, an entirely different thing as I just learned). After registering your `RawFd`'s, you had to pass the index of that fd as registered in the kernel fileset (not the fd itself) into prep methods. Then, you had to set `SubmissionFlags::FIXED_FILE` after the prep call. 

This PR introduces a new type representing a member of the kernel fileset called `RegisteredFd`. After a successful call to `Registrar::register_files(&fds)`, you can access the currently registered files using a new `Registrar` member function `fileset()`. This returns a slice of registered file references owned by the registrar.  The only way to get `RegisteredFd`s is through this method (not counting placeholders, see further on for more info). 

The `RegisteredFd`s can then be passed to prep methods just like `RawFd`.  I've added a private helper method `set_fixed_flag` so the users no longer have to set the flag themselves. 

There is also the possibility of "sparse" registered filesets where one reserves a large fileset filled with `-1`s to be filled in later using the new `update_registered_files` method.  I tried to implement these, but was unable to test them because my kernel is too old to support updates (see the ignored test `tests/fileset-placeholder.rs`). Regular fixed files seem to work OK (`tests/fixed-file-write.rs`)

I went off on a lark trying to implement a `reserve` method for the registrar but got stuck in temporary lifetime hell where adding a few print statements changed all my test failures to passes. 

The end result is users must construct a buffer of placeholder values outside the `register` call, to ensure they remain valid until the fileset is updated. 

Right now it looks like this
```rust
use iou::RegisteredFd; 
let placeholders = [RegisteredFd::placeholder().as_fd(); 4096]; 
registrar.register_files(&placeholders); 

// later 

offset = 0; 
registrar.update_registered_files(offset, &actual_fds); 
```
which isn't as nice as 

```rust
registrar.reserve(4096);
registrar.update_registered_files(offset, &actual_fds); 
```
but it is similar to how users have to handle other kinds of input buffers, and maybe that kind of high-level interface isn't what we're trying to build here anyway. 

Please let me know if you'd like any changes. The enum checking in each prep method is a little verbose but I thought it best to keep it more explicit at the prep call sites. 