### PR TITLE
sqe: change offset to u64

### DIFF
--- a/src/sqe.rs
+++ b/src/sqe.rs
@@ -190,7 +190,7 @@ impl<'a> SubmissionQueueEvent<'a> {
         &mut self,
         fd: RawFd,
         buf: &mut [u8],
-        offset: usize,
+        offset: u64,
         buf_index: usize,
     ) {
         let len = buf.len();
@@ -220,7 +220,7 @@ impl<'a> SubmissionQueueEvent<'a> {
         &mut self,
         fd: RawFd,
         buf: &[u8],
-        offset: usize,
+        offset: u64,
         buf_index: usize,
     ) {
         let len = buf.len();


### PR DESCRIPTION
An offset is a file position, so it can be bigger than usize in
32-bit platforms.