### PR TITLE
implement more prep operations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 bitflags = "1.2.0"
 nix = "0.16.0"
 uring-sys = "1.0.0-beta"
+libc = "0.2.65"
 
 [dev-dependencies]
 semver = "0.9.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@ use std::mem::MaybeUninit;
 use std::ptr::{self, NonNull};
 use std::time::Duration;
 
-pub use sqe::{SubmissionQueue, SubmissionQueueEvent, SubmissionFlags, FsyncFlags, SockAddrStorage};
+pub use sqe::{SubmissionQueue, SubmissionQueueEvent, SubmissionFlags, FsyncFlags, FallocateFlags, StatxFlags, StatxMode, OpenMode, SockAddrStorage};
 pub use cqe::{CompletionQueue, CompletionQueueEvent};
 pub use registrar::Registrar;
 


### PR DESCRIPTION
This patch implements a couple of more prep operations, for the
following opcodes:

 - IORING_OP_FALLOCATE,
 - IORING_OP_OPENAT,
 - IORING_OP_READ,
 - IORING_OP_WRITE,
 - IORING_OP_STATX

I did my best to strike a good balance between using friendly data
structures, especially for flags, and raw libc types. In particular:

 * for open, the "flags" field is kept as a libc::c_int, because that
   is the way that OpenFlagsExt uses to pass custom flags, but mode
   is made into a bitflag. A CString is used to hold the path name
   because we need something that can hold storage and play well with
   ffi.

 * for statx, flags are a bitflag but the buffer is written to a
   structure defined by the libc crate.

Those changes may require an update of the uring-sys crate. Locally,
I tested them with f567468d0edafe46e3c846fda6c9d7e765fc6e9c. Those
prep opcodes were not found in the version listed, 0.6.1