### PR TITLE
Document Personality struct and other doc fixes

### DIFF
--- a/src/completion_queue.rs
+++ b/src/completion_queue.rs
@@ -10,7 +10,7 @@ use super::{IoUring, CQE, CQEs, CQEsBlocking, resultify};
 ///
 /// Each element is a [`CQE`](crate::cqe::CQE).
 ///
-/// Completion does not imply success. Completed events may be [timeouts](crate::cqe::CQE::is_iou_timeout).
+/// Completion does not imply success; the event may have errored.
 pub struct CompletionQueue<'ring> {
     pub(crate) ring: NonNull<uring_sys::io_uring>,
     _marker: PhantomData<&'ring mut IoUring>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,9 +30,7 @@
 //!
 //! A timeout is submitted as an additional IO event which completes after the specified time.
 //! Therefore when you create a timeout, all that happens is that a completion event will appear
-//! after that specified time. This also means that when processing completion events, you need to
-//! be prepared for the possibility that the completion represents a timeout and not a normal IO
-//! event (`CQE` has a method to check for this).
+//! after that specified time.
 
 /// Types related to completion queue events.
 pub mod cqe;

--- a/src/sqe.rs
+++ b/src/sqe.rs
@@ -106,7 +106,7 @@ impl<'a> SQE<'a> {
     /// Prepare a read on a file descriptor.
     ///
     /// Both the file descriptor and the buffer can be pre-registered. See the
-    /// [`registrar][crate::registrar] module for more information.
+    /// [`registrar`][crate::registrar] module for more information.
     #[inline]
     pub unsafe fn prep_read(
         &mut self,
@@ -154,7 +154,7 @@ impl<'a> SQE<'a> {
     /// Prepare a write on a file descriptor.
     ///
     /// Both the file descriptor and the buffer can be pre-registered. See the
-    /// [`registrar][crate::registrar] module for more information.
+    /// [`registrar`][crate::registrar] module for more information.
     #[inline]
     pub unsafe fn prep_write(
         &mut self,


### PR DESCRIPTION
This PR documents the `Personality` struct and how to use it. The example is somewhat involved, but I tried to make it as simple as possible (adapted from the liburing test file [here](https://github.com/axboe/liburing/blob/a2141fc6718696db79101db358380a0490f6c506/test/personality.c)). There are two other small doc adjustments: 
* Take out references to the removed CQE method `is_iou_timeout` (e0c20f4)
* fix typo in `registrar` module link (54ce23a)