### PR TITLE
make buf_index u32 for prep_write_fixed

### DIFF
--- a/src/sqe.rs
+++ b/src/sqe.rs
@@ -190,7 +190,7 @@ impl<'a> SQE<'a> {
         fd: impl UringFd,
         buf: &[u8],
         offset: u64,
-        buf_index: usize,
+        buf_index: u32,
     ) {
         let len = buf.len();
         let addr = buf.as_ptr();


### PR DESCRIPTION
This is u32 for prep_read_fixed. It is confusing to have differing types
for both operations. Standardizing on u32 seems to match a trend towards
uring deterministic size types for these operations.