### PR TITLE
use 2018 idioms

### DIFF
--- a/src/completion_queue.rs
+++ b/src/completion_queue.rs
@@ -104,7 +104,7 @@ impl<'ring> CompletionQueue<'ring> {
 }
 
 impl fmt::Debug for CompletionQueue<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let fd = unsafe { self.ring.as_ref().ring_fd };
         f.debug_struct(std::any::type_name::<Self>()).field("fd", &fd).finish()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@
 //! after that specified time. This also means that when processing completion events, you need to
 //! be prepared for the possibility that the completion represents a timeout and not a normal IO
 //! event (`CQE` has a method to check for this).
-
+#![warn(rust_2018_idioms)]
 /// Types related to completion queue events.
 pub mod cqe;
 /// Types related to submission queue events.
@@ -360,7 +360,7 @@ impl IoUring {
 }
 
 impl fmt::Debug for IoUring {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct(std::any::type_name::<Self>()).field("fd", &self.ring.ring_fd).finish()
     }
 }

--- a/src/registrar/mod.rs
+++ b/src/registrar/mod.rs
@@ -250,7 +250,7 @@ impl<'ring> Registrar<'ring> {
 }
 
 impl fmt::Debug for Registrar<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let fd = unsafe { self.ring.as_ref().ring_fd };
         f.debug_struct(std::any::type_name::<Self>()).field("fd", &fd).finish()
     }

--- a/src/submission_queue.rs
+++ b/src/submission_queue.rs
@@ -132,7 +132,7 @@ impl<'ring> SubmissionQueue<'ring> {
 }
 
 impl fmt::Debug for SubmissionQueue<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let fd = unsafe { self.ring.as_ref().ring_fd };
         f.debug_struct(std::any::type_name::<Self>()).field("fd", &fd).finish()
     }


### PR DESCRIPTION
This patch fixes instances where the rust_2018 lint would complain.
They are related to elided lifetimes.

Because there are no other complains, I am taking the liberty of adding
the warning to the library definition so the code is kept compliant
in the future.