### PR TITLE
fix prepare_sqes

### DIFF
--- a/src/sqe.rs
+++ b/src/sqe.rs
@@ -4,7 +4,6 @@ use std::ffi::CStr;
 use std::ops::{Deref, DerefMut};
 use std::os::unix::io::RawFd;
 use std::ptr;
-use std::slice;
 
 use crate::registrar::{UringFd, UringReadBuf, UringWriteBuf};
 
@@ -22,7 +21,7 @@ use crate::Personality;
 /// Can be configured with a set of [`SubmissionFlags`](crate::sqe::SubmissionFlags).
 ///
 pub struct SQE<'a> {
-    sqe: &'a mut uring_sys::io_uring_sqe,
+    pub sqe: &'a mut uring_sys::io_uring_sqe,
 }
 
 impl<'a> SQE<'a> {
@@ -624,13 +623,19 @@ bitflags::bitflags! {
 
 /// A sequence of [`SQE`]s from the [`SubmissionQueue`][crate::SubmissionQueue].
 pub struct SQEs<'ring> {
-    sqes: slice::IterMut<'ring, uring_sys::io_uring_sqe>,
+    sq: &'ring mut uring_sys::io_uring_sq,
+    first: u32,
+    count: u32,
+    consumed: u32,
 }
 
 impl<'ring> SQEs<'ring> {
-    pub(crate) fn new(slice: &'ring mut [uring_sys::io_uring_sqe]) -> SQEs<'ring> {
+    pub(crate) fn new(sq: &'ring mut uring_sys::io_uring_sq, first: u32, count: u32) -> SQEs<'ring> {
         SQEs {
-            sqes: slice.iter_mut(),
+            sq,
+            first,
+            count,
+            consumed: 0,
         }
     }
 
@@ -660,14 +665,20 @@ impl<'ring> SQEs<'ring> {
 
     /// Remaining [`SQE`]s that can be modified.
     pub fn remaining(&self) -> u32 {
-        self.sqes.len() as u32
+        (self.count - self.consumed) as u32
     }
 
     fn consume(&mut self) -> Option<SQE<'ring>> {
-        self.sqes.next().map(|sqe| {
-            unsafe { uring_sys::io_uring_prep_nop(sqe) }
-            SQE { sqe }
-        })
+        if self.consumed < self.count {
+            unsafe {
+                let sqe = self.sq.sqes.offset(((self.first + self.consumed) & *self.sq.kring_mask) as isize);
+                uring_sys::io_uring_prep_nop(sqe);
+                self.consumed += 1;
+                Some(SQE { sqe: &mut *sqe })
+            }
+        } else {
+            None
+        }
     }
 }
 


### PR DESCRIPTION
This method takes a slice from the sqe queue, but that is completely
wrong: the sqe queue is a circular buffer, so if you try to get 2
elements at position n - 1 you access invalid memory.

This patch transforms the very helpful SQEs structure so that it now
only has the information needed to access each SQE and constructs them
from there.