### PR TITLE
Upgrade from uring-sys to uring-sys2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 bitflags = "1.2.0"
 nix = "0.18.0"
-uring-sys = "0.7.4"
+uring-sys = { package = "uring-sys2", version = "0.9.1" }
 libc = "0.2.77"
 
 [dev-dependencies]

--- a/src/completion_queue.rs
+++ b/src/completion_queue.rs
@@ -65,8 +65,8 @@ impl<'ring> CompletionQueue<'ring> {
                 self.ring.as_ptr(),
                 cqe.as_mut_ptr(),
                 count as _,
-                ptr::null(),
-                ptr::null(),
+                ptr::null_mut(),
+                ptr::null_mut(),
             ))?;
 
             Ok(&mut *cqe.assume_init())

--- a/src/cqe.rs
+++ b/src/cqe.rs
@@ -159,8 +159,8 @@ impl<'a> CQEsBlocking<'a> {
                 self.ring.as_ptr(),
                 cqe.as_mut_ptr(),
                 self.wait_for as _,
-                ptr::null(),
-                ptr::null(),
+                ptr::null_mut(),
+                ptr::null_mut(),
             ))?;
 
             Ok(&mut *cqe.assume_init())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,16 +97,26 @@ bitflags::bitflags! {
     /// ```
     pub struct SetupFlags: u32 {
         /// Poll the IO context instead of defaulting to interrupts.
-        const IOPOLL    = 1 << 0;   /* io_context is polled */
+        const IOPOLL                = uring_sys::IORING_SETUP_IOPOLL;   /* io_context is polled */
         /// Assign a kernel thread to poll the submission queue. Requires elevated privileges to set.
-        const SQPOLL    = 1 << 1;   /* SQ poll thread */
+        const SQPOLL                = uring_sys::IORING_SETUP_SQPOLL;   /* SQ poll thread */
         /// Force the kernel thread created with `SQPOLL` to be bound to the CPU used by the
         /// `SubmissionQueue`. Requires `SQPOLL` set.
-        const SQ_AFF    = 1 << 2;   /* sq_thread_cpu is valid */
+        const SQ_AFF                = uring_sys::IORING_SETUP_SQ_AFF;   /* sq_thread_cpu is valid */
 
-        const CQSIZE    = 1 << 3;
-        const CLAMP     = 1 << 4;
-        const ATTACH_WQ = 1 << 5;
+        const CQSIZE                = uring_sys::IORING_SETUP_CQSIZE;
+        const CLAMP                 = uring_sys::IORING_SETUP_CLAMP;
+        const ATTACH_WQ             = uring_sys::IORING_SETUP_ATTACH_WQ;
+        const R_DISABLED            = uring_sys::IORING_SETUP_R_DISABLED;
+        const SUBMIT_ALL            = uring_sys::IORING_SETUP_SUBMIT_ALL;
+        const COOP_TASKRUN          = uring_sys::IORING_SETUP_COOP_TASKRUN;
+        const TASKRUN_FLAG          = uring_sys::IORING_SETUP_TASKRUN_FLAG;
+        const SQE128                = uring_sys::IORING_SETUP_SQE128;
+        const CQE32                 = uring_sys::IORING_SETUP_CQE32;
+        const SINGLE_ISSUER         = uring_sys::IORING_SETUP_SINGLE_ISSUER;
+        const DEFER_TASKRUN         = uring_sys::IORING_SETUP_DEFER_TASKRUN;
+        const NO_MMAP               = uring_sys::IORING_SETUP_NO_MMAP;
+        const REGISTERED_FD_ONLY    = uring_sys::IORING_SETUP_REGISTERED_FD_ONLY;
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,13 +123,20 @@ bitflags::bitflags! {
 bitflags::bitflags! {
     /// Advanced features that can be enabled when setting up an [`IoUring`] instance.
     pub struct SetupFeatures: u32 {
-        const SINGLE_MMAP       = 1 << 0;
-        const NODROP            = 1 << 1;
-        const SUBMIT_STABLE     = 1 << 2;
-        const RW_CUR_POS        = 1 << 3;
-        const CUR_PERSONALITY   = 1 << 4;
-        const FAST_POLL         = 1 << 5;
-        const POLL_32BITS       = 1 << 6;
+        const SINGLE_MMAP       = uring_sys::IORING_FEAT_SINGLE_MMAP;
+        const NODROP            = uring_sys::IORING_FEAT_NODROP;
+        const SUBMIT_STABLE     = uring_sys::IORING_FEAT_SUBMIT_STABLE;
+        const RW_CUR_POS        = uring_sys::IORING_FEAT_RW_CUR_POS;
+        const CUR_PERSONALITY   = uring_sys::IORING_FEAT_CUR_PERSONALITY;
+        const FAST_POLL         = uring_sys::IORING_FEAT_FAST_POLL;
+        const POLL_32BITS       = uring_sys::IORING_FEAT_POLL_32BITS;
+        const SQPOLL_NONFIXED   = uring_sys::IORING_FEAT_SQPOLL_NONFIXED;
+        const EXT_ARG           = uring_sys::IORING_FEAT_EXT_ARG;
+        const NATIVE_WORKERS    = uring_sys::IORING_FEAT_NATIVE_WORKERS;
+        const RSRC_TAGS         = uring_sys::IORING_FEAT_RSRC_TAGS;
+        const CQE_SKIP          = uring_sys::IORING_FEAT_CQE_SKIP;
+        const LINKED_FILE       = uring_sys::IORING_FEAT_LINKED_FILE;
+        const REG_REG_RING      = uring_sys::IORING_FEAT_REG_REG_RING;
     }
 }
 

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -22,7 +22,7 @@ impl Probe {
         }
     }
 
-    pub fn supports(&self, op: uring_sys::IoRingOp) -> bool {
+    pub fn supports(&self, op: uring_sys::io_uring_op) -> bool {
         unsafe { uring_sys::io_uring_opcode_supported(self.probe.as_ptr(), op as _) != 0 }
     }
 }

--- a/src/registrar/mod.rs
+++ b/src/registrar/mod.rs
@@ -291,7 +291,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Device or resource busy")]
+    #[should_panic(expected = "Resource busy")]
     fn double_register() {
         let ring = IoUring::new(1).unwrap();
         let _ = ring.registrar().register_files(&[1]).unwrap();

--- a/src/submission_queue.rs
+++ b/src/submission_queue.rs
@@ -113,7 +113,7 @@ impl<'ring> SubmissionQueue<'ring> {
                 sqe.clear();
                 unsafe {
                     sqe.prep_timeout(&ts, 0, crate::sqe::TimeoutFlags::empty());
-                    sqe.set_user_data(uring_sys::LIBURING_UDATA_TIMEOUT);
+                    sqe.set_user_data(libc::__u64::max_value());
                     return resultify(uring_sys::io_uring_submit_and_wait(self.ring.as_ptr(), wait_for as _))
                 }
             }

--- a/tests/probe.rs
+++ b/tests/probe.rs
@@ -1,8 +1,8 @@
 use iou::Probe;
-use uring_sys::IoRingOp;
+use uring_sys::io_uring_op;
 
 #[test]
 fn probe() {
     let probe = Probe::new().unwrap();
-    assert!(probe.supports(IoRingOp::IORING_OP_NOP));
+    assert!(probe.supports(io_uring_op::IORING_OP_NOP));
 }

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -91,7 +91,7 @@ fn read_registered_buf() -> io::Result<()> {
         let mut sqe = sq.prepare_sqe().unwrap();
         sqe.prep_read(file.as_raw_fd(), buf.as_mut(), 0);
         sqe.set_user_data(0xDEADBEEF);
-        assert!(sqe.raw().opcode == uring_sys::IoRingOp::IORING_OP_READ_FIXED as u8);
+        assert!(sqe.raw().opcode == uring_sys::io_uring_op::IORING_OP_READ_FIXED as u8);
         sq.submit()?;
     }
 
@@ -126,7 +126,7 @@ fn read_registered_fd_and_buf() -> io::Result<()> {
         let mut sqe = sq.prepare_sqe().unwrap();
         sqe.prep_read(fd, buf.as_mut(), 0);
         sqe.set_user_data(0xDEADBEEF);
-        assert!(sqe.raw().opcode == uring_sys::IoRingOp::IORING_OP_READ_FIXED as u8);
+        assert!(sqe.raw().opcode == uring_sys::io_uring_op::IORING_OP_READ_FIXED as u8);
         assert!(sqe.flags().contains(iou::sqe::SubmissionFlags::FIXED_FILE));
         sq.submit()?;
     }

--- a/tests/write.rs
+++ b/tests/write.rs
@@ -110,7 +110,7 @@ fn write_registered_buf() -> io::Result<()> {
             let mut sq = io_uring.sq();
             let mut sqe = sq.prepare_sqe().unwrap();
             sqe.prep_write(file.as_raw_fd(), buf.slice_to(TEXT.len()), 0);
-            assert!(sqe.raw().opcode == uring_sys::IoRingOp::IORING_OP_WRITE_FIXED as u8);
+            assert!(sqe.raw().opcode == uring_sys::io_uring_op::IORING_OP_WRITE_FIXED as u8);
             sqe.set_user_data(0xDEADBEEF);
             io_uring.sq().submit()?;
         }


### PR DESCRIPTION
At this time, [`uring-sys`](https://crates.io/crates/uring-sys) did not receive any updates in three and a half years. Open PRs seemingly never got merged, including one PR supplying a fix enabling `uring-sys` being built on musl-systems. For now, we have to assume it's abandoned.

Luckily, a drop-in replacement which still receives updates and fixes exists in the form of [`uring-sys2`](https://crates.io/crates/uring-sys2), a fork of `uring-sys`. This PR switches over to `uring-sys2`. In addition, it adds `SetupFlags` and `SetupFeatures` constants which were introduced with newer versions of `liburing`.